### PR TITLE
Adds PropertySource to application context

### DIFF
--- a/src/main/java/de/otto/edison/jobtrigger/Server.java
+++ b/src/main/java/de/otto/edison/jobtrigger/Server.java
@@ -4,12 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.PropertySource;
 
 /*
 Extend the basePackages to de.otto.edison so SpringBoot is able to find
 the components configured by edison-microservice
 */
 @ComponentScan(basePackages = "de.otto.edison")
+@PropertySource("version.properties")
 @SpringBootApplication
 public class Server {
 


### PR DESCRIPTION
We added the version.properties as PropertySource. Otherwise the version/commit will not be set on the status page.